### PR TITLE
address #142 (refactor typo in variable and function names)

### DIFF
--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/data/LinkInfo.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/data/LinkInfo.java
@@ -13,7 +13,7 @@ public class LinkInfo {
 
     private final Id<Link> linkId;
 
-    private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime = new HashMap<>();
+    private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualtyExposureByAccidentTypeByTime = new HashMap<>();
 
     private Map<Pollutant, OpenIntFloatHashMap> exposure2Pollutant2TimeBin = new HashMap<>();
 
@@ -29,12 +29,12 @@ public class LinkInfo {
         return linkId;
     }
 
-    public Map<AccidentType, OpenIntFloatHashMap> getSevereFatalCasualityExposureByAccidentTypeByTime() {
-        return severeFatalCasualityExposureByAccidentTypeByTime;
+    public Map<AccidentType, OpenIntFloatHashMap> getSevereFatalCasualtyExposureByAccidentTypeByTime() {
+        return severeFatalCasualtyExposureByAccidentTypeByTime;
     }
 
-    public void setSevereFatalCasualityExposureByAccidentTypeByTime(Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime) {
-        this.severeFatalCasualityExposureByAccidentTypeByTime = severeFatalCasualityExposureByAccidentTypeByTime;
+    public void setSevereFatalCasualtyExposureByAccidentTypeByTime(Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualtyExposureByAccidentTypeByTime) {
+        this.severeFatalCasualtyExposureByAccidentTypeByTime = severeFatalCasualtyExposureByAccidentTypeByTime;
     }
 
     public Map<Pollutant, OpenIntFloatHashMap> getExposure2Pollutant2TimeBin() {
@@ -62,7 +62,7 @@ public class LinkInfo {
     }
 
     public void reset(){
-        severeFatalCasualityExposureByAccidentTypeByTime.clear();
+        severeFatalCasualtyExposureByAccidentTypeByTime.clear();
         exposure2Pollutant2TimeBin.clear();
         noiseLevel2TimeBin.clear();
     }

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentLinkInfo.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentLinkInfo.java
@@ -19,7 +19,6 @@
 
 package de.tum.bgu.msm.health.injury;
 
-import cern.colt.map.tdouble.OpenIntDoubleHashMap;
 import cern.colt.map.tfloat.OpenIntFloatHashMap;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -37,17 +36,9 @@ public class AccidentLinkInfo {
 	
 	private final Map<Integer, TimeBinInfo> timeSpecificInfo = new HashMap<>();
 
-//	private  Map<AccidentType, Map<Integer, Double>> lightCrashRateByAccidentTypeByTime = new HashMap<>();
-//
-//	private  Map<AccidentType, Map<Integer, Double>> severeFatalCrashRateByAccidentTypeByTime = new HashMap<>();
-//
-//	private  Map<AccidentType, Map<Integer, Double>> lightCasualityRateByAccidentTypeByTime = new HashMap<>();
-//
-//	private  Map<AccidentType, Map<Integer, Double>> severeFatalCasualityRateByAccidentTypeByTime = new HashMap<>();
+	private  Map<AccidentType, OpenIntFloatHashMap> lightCasualtyExposureByAccidentTypeByTime = new HashMap<>();
 
-	private  Map<AccidentType, OpenIntFloatHashMap> lightCasualityExposureByAccidentTypeByTime = new HashMap<>();
-
-	private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualityExposureByAccidentTypeByTime = new HashMap<>();
+	private  Map<AccidentType, OpenIntFloatHashMap> severeFatalCasualtyExposureByAccidentTypeByTime = new HashMap<>();
 
 	public AccidentLinkInfo(Id<Link> linkId) {
 		this.linkId = linkId;
@@ -61,28 +52,12 @@ public class AccidentLinkInfo {
 		return timeSpecificInfo;
 	}
 
-//	public Map<AccidentType, Map<Integer, Double>> getLightCrashRateByAccidentTypeByTime() {
-//		return lightCrashRateByAccidentTypeByTime;
-//	}
-//
-//	public Map<AccidentType, Map<Integer, Double>> getSevereFatalCrashRateByAccidentTypeByTime() {
-//		return severeFatalCrashRateByAccidentTypeByTime;
-//	}
-//
-//	public Map<AccidentType, Map<Integer, Double>> getLightCasualityRateByAccidentTypeByTime() {
-//		return lightCasualityRateByAccidentTypeByTime;
-//	}
-//
-//	public Map<AccidentType, Map<Integer, Double>> getSevereFatalCasualityRateByAccidentTypeByTime() {
-//		return severeFatalCasualityRateByAccidentTypeByTime;
-//	}
-
-	public Map<AccidentType, OpenIntFloatHashMap> getLightCasualityExposureByAccidentTypeByTime() {
-		return lightCasualityExposureByAccidentTypeByTime;
+	public Map<AccidentType, OpenIntFloatHashMap> getLightCasualtyExposureByAccidentTypeByTime() {
+		return lightCasualtyExposureByAccidentTypeByTime;
 	}
 
-	public Map<AccidentType, OpenIntFloatHashMap> getSevereFatalCasualityExposureByAccidentTypeByTime() {
-		return severeFatalCasualityExposureByAccidentTypeByTime;
+	public Map<AccidentType, OpenIntFloatHashMap> getSevereFatalCasualtyExposureByAccidentTypeByTime() {
+		return severeFatalCasualtyExposureByAccidentTypeByTime;
 	}
 }
 

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentModel.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentModel.java
@@ -67,11 +67,8 @@ public class AccidentModel extends AbstractModel implements ModelUpdateListener 
             model.runModelOnline();
 
             for(Id<Link> linkId : model.getAccidentsContext().getLinkId2info().keySet()){
-//                ((de.tum.bgu.msm.scenarios.health.HealthDataContainerImpl)dataContainer).getLinkInfoByDay().get(day).get(linkId).
-//                        setLightCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getLightCasualityExposureByAccidentTypeByTime());
-//
                 ((DataContainerHealth)dataContainer).getLinkInfo().get(linkId).
-                        setSevereFatalCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualityExposureByAccidentTypeByTime());
+                        setSevereFatalCasualtyExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualtyExposureByAccidentTypeByTime());
             }
             model.getAccidentsContext().reset();
     }

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentRateCalculation.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentRateCalculation.java
@@ -51,10 +51,10 @@ public class AccidentRateCalculation {
 
         switch (accidentSeverity){
             case LIGHT:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
                 break;
             case SEVEREFATAL:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
                 break;
             default:
                 throw new RuntimeException("Undefined accident severity " + accidentSeverity);

--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentRateModel.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/injury/AccidentRateModel.java
@@ -411,18 +411,18 @@ public class AccidentRateModel {
                 String mode = personInfo.getLinkId2time2mode().get(linkId).get(hour);
                 switch (mode){
                     case "car":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
                         break;
                     case "bike":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
                         break;
                     case "walk":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
                         break;
                     default:
                         throw new RuntimeException("Undefined mode " + mode);
@@ -444,12 +444,12 @@ public class AccidentRateModel {
                 float lightCrash = 0.0f;
                 float severeCrash = 0.0f;
 
-                if(linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(accidentType)!=null){
-                    lightCrash = linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                if(linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(accidentType)!=null){
+                    lightCrash = linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 }
 
-                if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType)!=null){
-                    severeCrash = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                if(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType)!=null){
+                    severeCrash = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 }
 
                  switch (accidentType){
@@ -479,8 +479,8 @@ public class AccidentRateModel {
                 lightCasualtyByTime.put(hour,lightCasualty);
                 severeCasualtyByTime.put(hour,severeCasualty);
             }
-            linkInfo.getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyByTime);
-            linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType,severeCasualtyByTime);
+            linkInfo.getLightCasualtyExposureByAccidentTypeByTime().put(accidentType,lightCasualtyByTime);
+            linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType,severeCasualtyByTime);
         }
     }
 
@@ -511,8 +511,8 @@ public class AccidentRateModel {
             OpenIntFloatHashMap lightCasualtyExposureByTime = new OpenIntFloatHashMap();
             OpenIntFloatHashMap severeCasualtyExposureByTime = new OpenIntFloatHashMap();
             for(int hour = 0; hour < 24; hour++) {
-                float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 float lightCasualtyExposure =0.f;
                 float severeCasualtyExposure = 0.f;
                 if(mode.equals("car")){
@@ -535,8 +535,8 @@ public class AccidentRateModel {
                 lightCasualtyExposureByTime.put(hour,lightCasualtyExposure);
                 severeCasualtyExposureByTime.put(hour,severeCasualtyExposure);
             }
-            this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
-            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType,severeCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType,severeCasualtyExposureByTime);
 
         }
     }
@@ -578,9 +578,9 @@ public class AccidentRateModel {
                     double totalCasualty = 0.;
                     for(int hour = 0; hour<=24; hour++) {
                         if(accidentSeverity.equals(AccidentSeverity.LIGHT)){
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }else{
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                     }
                     risk.append(link.getId());
@@ -613,9 +613,9 @@ public class AccidentRateModel {
                     double totalCasualty = 0.;
                     for(int hour = 0; hour<=24; hour++) {
                         if(accidentSeverity.equals(AccidentSeverity.LIGHT)){
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }else{
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                     }
                     risk.append(link.getId());
@@ -648,9 +648,9 @@ public class AccidentRateModel {
                     double totalCasualty = 0.;
                     for(int hour = 0; hour<=24; hour++) {
                         if(accidentSeverity.equals(AccidentSeverity.LIGHT)){
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }else{
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                     }
                     risk.append(link.getId());

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentModelMCR.java
@@ -3,23 +3,17 @@ package de.tum.bgu.msm.health;
 import cern.colt.map.tfloat.OpenIntFloatHashMap;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.Day;
-import de.tum.bgu.msm.health.airPollutant.emission.MCRHbefaRoadTypeMapping;
-import de.tum.bgu.msm.health.data.DataContainerHealth;
 import de.tum.bgu.msm.health.data.LinkInfo;
-import de.tum.bgu.msm.health.injury.AccidentRateModel;
 import de.tum.bgu.msm.health.injury.AccidentType;
 import de.tum.bgu.msm.models.AbstractModel;
 import de.tum.bgu.msm.models.ModelUpdateListener;
 import de.tum.bgu.msm.properties.Properties;
-import de.tum.bgu.msm.resources.Resources;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
 
@@ -111,9 +105,7 @@ public class AccidentModelMCR extends AbstractModel implements ModelUpdateListen
             model.runCasualtyRateMCR();
 
             for (Id<Link> linkId : model.getAccidentsContext().getLinkId2info().keySet()) {
-                //((de.tum.bgu.msm.scenarios.health.HealthDataContainerImpl)dataContainer).getLinkInfoByDay().get(day).get(linkId).setLightCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getLightCasualityExposureByAccidentTypeByTime());
-                //((DataContainerHealth) dataContainer).getLinkInfo().get(linkId).setSevereFatalCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualityExposureByAccidentTypeByTime());
-                ((HealthDataContainerImpl) dataContainer).getLinkInfoByDay(day).get(linkId).setSevereFatalCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualityExposureByAccidentTypeByTime());
+                ((HealthDataContainerImpl) dataContainer).getLinkInfoByDay(day).get(linkId).setSevereFatalCasualtyExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualtyExposureByAccidentTypeByTime());
             }
 
             logger.info("====================");
@@ -145,7 +137,7 @@ public class AccidentModelMCR extends AbstractModel implements ModelUpdateListen
                     for (int hour = 0; hour < 24; hour++) {
                         // Retrieve the hourly risk map for the accidentType, defaulting to an empty OpenIntFloatHashMap
                         OpenIntFloatHashMap hourlyRiskMap = linkInfo
-                                .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                                .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                                 .getOrDefault(accidentType, new OpenIntFloatHashMap());
 
                         // Add the risk for the current hour, defaulting to 0.0 if not present
@@ -161,23 +153,6 @@ public class AccidentModelMCR extends AbstractModel implements ModelUpdateListen
             for (AccidentType accidentType : AccidentType.values()) {
                 logger.info("Accident Type: {}, Total Risk: {}", accidentType, totalRiskByAccidentType.get(accidentType));
             }
-
-
-
-            // check
-            /*
-            for (Id<Link> linkId : model.getAccidentsContext().getLinkId2info().keySet()) {
-                //((de.tum.bgu.msm.scenarios.health.HealthDataContainerImpl)dataContainer).getLinkInfoByDay().get(day).get(linkId).setLightCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getLightCasualityExposureByAccidentTypeByTime());
-                //((DataContainerHealth) dataContainer).getLinkInfo().get(linkId).setSevereFatalCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualityExposureByAccidentTypeByTime());
-
-                for(int hour =0; hour<24; hour++){
-                    double risk= ((HealthDataContainerImpl) dataContainer).getLinkInfoByDay(day).get(linkId).getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
-                    logger.warn("risk = " + risk);
-                }
-
-            }
-
-             */
 
             model.getAccidentsContext().reset();
         }

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentRateCalculationMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentRateCalculationMCR.java
@@ -52,10 +52,10 @@ public class AccidentRateCalculationMCR {
 
         switch (accidentSeverity){
             case LIGHT:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
                 break;
             case SEVEREFATAL:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
                 break;
             default:
                 throw new RuntimeException("Undefined accident severity " + accidentSeverity);

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentRateModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentRateModelMCR.java
@@ -930,7 +930,7 @@ public class AccidentRateModelMCR {
     }
 
     private double calculateRiskForMode(AccidentLinkInfo linkInfo, String mode, int hour) {
-        Map<AccidentType, OpenIntFloatHashMap> exposureByType = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime();
+        Map<AccidentType, OpenIntFloatHashMap> exposureByType = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime();
 
         switch (mode) {
             // todo: here normally if ONEWAY is 0 other is non-null and vice versa, same for BIKE ...
@@ -953,72 +953,6 @@ public class AccidentRateModelMCR {
         return map.get(hour);
     }
 
-    /*
-    private void computeAgentCrashRiskMCR(AccidentAgentInfo personInfo) {
-
-        //double lightInjuryRisk = .0;
-        Double severeInjuryRisk = .0;
-        Map<String, Double> PersonInjuryRiskByMode = new HashMap<>();
-
-        // Initialize modes
-        PersonInjuryRiskByMode.put("car", 0.0);
-        PersonInjuryRiskByMode.put("bike", 0.0);
-        PersonInjuryRiskByMode.put("walk", 0.0);
-
-        for(Id<Link> linkId : personInfo.getLinkId2time2mode().keySet()){
-            AccidentLinkInfo linkInfo = this.accidentsContext.getLinkId2info().get(linkId);
-            if(linkInfo == null){
-                log.warn(linkId + " has no Link Info.");
-                continue;
-            }
-
-            for(int hour : personInfo.getLinkId2time2mode().get(linkId).keySet()){
-                String mode = personInfo.getLinkId2time2mode().get(linkId).get(hour);
-                switch (mode){
-                    case "car":
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.CAR_ONEWAY)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR_ONEWAY).get(hour);
-                        }
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.CAR_TWOWAY)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR_TWOWAY).get(hour);
-                        }
-                        if(severeInjuryRisk != null){
-                            PersonInjuryRiskByMode.put("car", PersonInjuryRiskByMode.get("car") + severeInjuryRisk);
-                        }
-
-                        severeInjuryRisk = .0;
-                        break;
-                    case "bike":
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.BIKE_MAJOR)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKE_MAJOR).get(hour);
-                        }
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.BIKE_MINOR)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKE_MINOR).get(hour);
-                        }
-                        if(severeInjuryRisk != null){
-                            PersonInjuryRiskByMode.put("bike", PersonInjuryRiskByMode.get("bike") + severeInjuryRisk);
-                        }
-                        severeInjuryRisk = .0;
-                        break;
-                    case "walk":
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.PED)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
-                        }
-                        if(severeInjuryRisk != null){
-                            PersonInjuryRiskByMode.put("walk", PersonInjuryRiskByMode.get("walk") + severeInjuryRisk);
-                        }
-                        severeInjuryRisk = .0;
-                        break;
-                    default:
-                        throw new RuntimeException("Undefined mode " + mode);
-                }
-            }
-        }
-        //personInfo.setSevereInjuryRisk(severeInjuryRisk);
-        personInfo.setSevereInjuryRiskByMode(PersonInjuryRiskByMode);
-    }
-     */
-
     private void computeAgentCrashRisk(AccidentAgentInfo personInfo) {
 
         double lightInjuryRisk = .0;
@@ -1033,18 +967,18 @@ public class AccidentRateModelMCR {
                 String mode = personInfo.getLinkId2time2mode().get(linkId).get(hour);
                 switch (mode){
                     case "car":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
                         break;
                     case "bike":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
                         break;
                     case "walk":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
                         break;
                     default:
                         throw new RuntimeException("Undefined mode " + mode);
@@ -1066,12 +1000,12 @@ public class AccidentRateModelMCR {
                 float lightCrash = 0.0f;
                 float severeCrash = 0.0f;
 
-                if(linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(accidentType)!=null){
-                    lightCrash = linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                if(linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(accidentType)!=null){
+                    lightCrash = linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 }
 
-                if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType)!=null){
-                    severeCrash = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                if(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType)!=null){
+                    severeCrash = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 }
 
                  switch (accidentType){
@@ -1101,8 +1035,8 @@ public class AccidentRateModelMCR {
                 lightCasualtyByTime.put(hour,lightCasualty);
                 severeCasualtyByTime.put(hour,severeCasualty);
             }
-            linkInfo.getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyByTime);
-            linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType,severeCasualtyByTime);
+            linkInfo.getLightCasualtyExposureByAccidentTypeByTime().put(accidentType,lightCasualtyByTime);
+            linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType,severeCasualtyByTime);
         }
     }
 
@@ -1141,15 +1075,10 @@ public class AccidentRateModelMCR {
             for(int hour = 0; hour < 24; hour++) {
                 OpenIntFloatHashMap timeMap = this.accidentsContext.getLinkId2info()
                         .get(link.getId())
-                        .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                        .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                         .get(accidentType);
 
                 float severeCasualty = (timeMap != null) ? timeMap.get(hour) : 0.0f;
-
-                //float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                //float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                //float lightCasualtyExposure =0.f;
-
                 float severeCasualtyExposure = 0.f;
                 if(mode.equals("car")){
                     if(analysisEventHandler.getDemand(link.getId(), mode, hour) != 0){
@@ -1173,14 +1102,9 @@ public class AccidentRateModelMCR {
                         }
                     }
                 }
-
-                //lightCasualtyExposureByTime.put(hour,lightCasualtyExposure);
-                // TODO: can be optimized, if 0 do not put
-                //severeCasualtyExposure = severeCasualtyExposure * 2.0f;
                 severeCasualtyExposureByTime.put(hour, severeCasualtyExposure);
             }
-            //this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
-            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, severeCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, severeCasualtyExposureByTime);
         }
     }
 
@@ -1211,8 +1135,8 @@ public class AccidentRateModelMCR {
             OpenIntFloatHashMap lightCasualtyExposureByTime = new OpenIntFloatHashMap();
             OpenIntFloatHashMap severeCasualtyExposureByTime = new OpenIntFloatHashMap();
             for(int hour = 0; hour < 24; hour++) {
-                float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 float lightCasualtyExposure =0.f;
                 float severeCasualtyExposure = 0.f;
                 if(mode.equals("car")){
@@ -1235,8 +1159,8 @@ public class AccidentRateModelMCR {
                 lightCasualtyExposureByTime.put(hour,lightCasualtyExposure);
                 severeCasualtyExposureByTime.put(hour,severeCasualtyExposure);
             }
-            this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
-            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType,severeCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType,severeCasualtyExposureByTime);
 
         }
     }
@@ -1285,9 +1209,9 @@ public class AccidentRateModelMCR {
                         continue;
                     }
                     double totalCasualty = 0.;
-                    if(accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType) != null){
+                    if(accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType) != null){
                         for(int hour = 0; hour < 24; hour++) {
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                         risk.append(link.getId());
                         risk.append(',');
@@ -1317,9 +1241,9 @@ public class AccidentRateModelMCR {
                     double totalCasualty = 0.;
                     for(int hour = 0; hour<=24; hour++) {
                         if(accidentSeverity.equals(AccidentSeverity.LIGHT)){
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }else{
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                     }
                     risk.append(link.getId());
@@ -1357,7 +1281,7 @@ public class AccidentRateModelMCR {
                     }
                     double totalCasualty = 0.;
                     for(int hour = 0; hour < 24; hour++) {
-                        totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                        totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                     }
                     risk.append(link.getId());
                     risk.append(',');

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentRateModelOsmMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/AccidentRateModelOsmMCR.java
@@ -8,11 +8,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.LinkEnterEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.accidents.AccidentsModule;
-import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Injector;
 import org.matsim.core.events.EventsManagerImpl;
@@ -350,7 +348,7 @@ public class AccidentRateModelOsmMCR {
                     severeCasualtyExposureByTime.put(hour, exposure);
                 }
                 accidentsContext.getLinkId2info().get(link.getId())
-                        .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                        .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                         .put(accidentType, severeCasualtyExposureByTime);
             }
         }
@@ -410,7 +408,7 @@ public class AccidentRateModelOsmMCR {
     private float getSevereCasualty(Id<Link> linkId, AccidentType accidentType, int hour) {
         OpenIntFloatHashMap timeMap = accidentsContext.getLinkId2info()
                 .get(linkId)
-                .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                 .get(accidentType);
         return timeMap != null ? timeMap.get(hour) : 0.0f;
     }
@@ -442,10 +440,10 @@ public class AccidentRateModelOsmMCR {
                         if (ACCIDENT_TYPES_EXCLUDED.contains(accidentType)) continue;
                         for (AccidentSeverity accidentSeverity : AccidentSeverity.values()) {
                             if (ACCIDENT_SEVERITIES_EXCLUDED.contains(accidentSeverity)) continue;
-                            if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType) != null) {
+                            if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType) != null) {
                                 for (int hour = 0; hour < 24; hour++) {
                                     double casualty = accidentsContext.getLinkId2info().get(link.getId())
-                                            .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                                            .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                                             .get(accidentType).get(hour);
                                     if (casualty > 0) {
                                         writer.printf("%d,%s,%s,%d,%s\n",
@@ -482,10 +480,10 @@ public class AccidentRateModelOsmMCR {
 
                      */
                         double totalCasualty = 0;
-                        if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType) != null) {
+                        if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType) != null) {
 
                             for (int hour = 0; hour < 24; hour++) {
-                                totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                                totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
 
                             }
 
@@ -510,7 +508,7 @@ public class AccidentRateModelOsmMCR {
     private double calculateTotalCasualty(Id<Link> linkId, AccidentType accidentType) {
         OpenIntFloatHashMap timeMap = accidentsContext.getLinkId2info()
                 .get(linkId)
-                .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                 .get(accidentType);
         if (timeMap == null) return 0.0;
         double total = 0.0;

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationMCR.java
@@ -1,11 +1,9 @@
 package de.tum.bgu.msm.health;
 
 import cern.colt.map.tfloat.OpenIntFloatHashMap;
-import de.tum.bgu.msm.health.data.LinkInfo;
 import de.tum.bgu.msm.health.injury.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.utils.objectattributes.attributable.Attributes;
@@ -29,9 +27,6 @@ public class CasualtyRateCalculationMCR {
     private double calibrationFactor;
     private int tot_Casualties;
     private int current_Casualties;
-
-    // todo: testing
-    //private Map<Id<Link>, EnumMap<AccidentType, OpenIntFloatHashMap>> severeFatalCasualityRiskByLinkByAccidentTypeByTime = new HashMap<>();
 
     public CasualtyRateCalculationMCR(double scaleFactor, AccidentsContext accidentsContext, AnalysisEventHandler analzyer, AccidentType accidentType, AccidentSeverity accidentSeverity, String basePath, Scenario scenario, double calibrationFactor) {
         this.SCALEFACTOR = scaleFactor;
@@ -147,7 +142,7 @@ public class CasualtyRateCalculationMCR {
 
         switch (accidentSeverity) {
             case SEVEREFATAL:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
                 break;
             default:
                 throw new RuntimeException("Undefined accident severity " + accidentSeverity);
@@ -202,7 +197,7 @@ public class CasualtyRateCalculationMCR {
         int val = 0;
 
         //
-        OpenIntFloatHashMap casualtyRateByTimeOfDay = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().getOrDefault(accidentType, new OpenIntFloatHashMap());
+        OpenIntFloatHashMap casualtyRateByTimeOfDay = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().getOrDefault(accidentType, new OpenIntFloatHashMap());
 
         for (int hour = 0; hour < 24; hour++) {
             if(analzyer.getDemand(link.getId(), getMode(accidentType), hour) > 0 && casualtyRateByTimeOfDay.get(hour) == 0) {
@@ -222,7 +217,7 @@ public class CasualtyRateCalculationMCR {
         }
 
         // update map
-        this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
+        this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
     }
 
     private void printLinkInfo(Link link) {

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationOsmMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationOsmMCR.java
@@ -4,17 +4,11 @@ import cern.colt.map.tfloat.OpenIntFloatHashMap;
 import de.tum.bgu.msm.health.injury.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.utils.objectattributes.attributable.Attributes;
-import routing.components.JctStress;
-import routing.components.LinkStress;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 public class CasualtyRateCalculationOsmMCR {
     private static final Logger log = LogManager.getLogger(CasualtyRateCalculationOsmMCR.class);
@@ -33,7 +27,6 @@ public class CasualtyRateCalculationOsmMCR {
     //private int current_Casualties;
 
     // todo: testing
-    //private Map<Id<Link>, EnumMap<AccidentType, OpenIntFloatHashMap>> severeFatalCasualityRiskByLinkByAccidentTypeByTime = new HashMap<>();
 
     public CasualtyRateCalculationOsmMCR(AccidentsContext accidentsContext, AccidentType accidentType, AccidentSeverity accidentSeverity, String basePath) {
         //this.SCALEFACTOR = scaleFactor;
@@ -92,37 +85,8 @@ public class CasualtyRateCalculationOsmMCR {
                 linkCasualtyRateByTime.put(hour, linkCasualtyRate);
             }
             AccidentLinkInfo linkInfo = accidentsContext.getLinkId2info().computeIfAbsent(link.getId(), id -> new AccidentLinkInfo(id));
-            linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, linkCasualtyRateByTime);
+            linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, linkCasualtyRateByTime);
         }
-
-
-        // testing
-        /*
-        if(osmLink.osmId== 1111480){
-            System.out.println("OSM ID " + osmLink.osmId);
-            System.out.println("===============================================================");
-            printOsmLinkDetails(osmLink);
-            System.out.println("===============================================================");
-            printBinaryLogitCoefficients();
-            System.out.println("===============================================================");
-            for(int hour = 0; hour < 24; hour++) {
-                System.out.println("Hour " + hour + ": " + casualtyRateByTimeOfDay.get(hour));
-            }
-            System.out.println("===============================================================");
-
-            // links
-            for(Link link : osmLink.getNetworkLinks()) {
-                System.out.println("Link ID " + link.getId().toString());
-                System.out.println("===============================================================");
-                for(int hour = 0; hour < 24; hour++) {
-                    float val = accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                    System.out.println("Hour " + hour + ": " + val);
-                }
-                System.out.println("===============================================================");
-            }
-        }
-
-         */
     }
 
     public void printBinaryLogitCoefficients() {

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/HealthExposureModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/HealthExposureModelMCR.java
@@ -8,7 +8,6 @@ import de.tum.bgu.msm.data.*;
 import de.tum.bgu.msm.data.job.JobMCR;
 import de.tum.bgu.msm.data.person.Gender;
 import de.tum.bgu.msm.data.person.Person;
-import de.tum.bgu.msm.data.travelTimes.SkimTravelTimes;
 import de.tum.bgu.msm.health.data.*;
 import de.tum.bgu.msm.health.diseaseModelOffline.HealthExposuresReader;
 import de.tum.bgu.msm.health.injury.AccidentType;
@@ -23,16 +22,12 @@ import de.tum.bgu.msm.properties.Properties;
 import de.tum.bgu.msm.util.concurrent.ConcurrentExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.locationtech.jts.geom.Coordinate;
-import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.PopulationFactory;
-import org.matsim.contrib.analysis.vsp.traveltimedistance.TripsExtractor;
 import org.matsim.contrib.dvrp.trafficmonitoring.TravelTimeUtils;
 import org.matsim.contrib.emissions.Pollutant;
 import org.matsim.core.config.Config;
@@ -58,8 +53,6 @@ import routing.components.JctStress;
 import routing.components.LinkAmbience;
 import routing.components.LinkStress;
 import routing.travelDisutility.ActiveDisutilityPrecalc;
-import routing.travelTime.BicycleLinkSpeedCalculatorImpl;
-import routing.travelTime.BicycleTravelTime;
 import routing.travelTime.WalkLinkSpeedCalculatorImpl;
 import routing.travelTime.WalkTravelTime;
 
@@ -1560,21 +1553,21 @@ public class HealthExposureModelMCR extends AbstractModel implements ModelUpdate
         switch (mode) {
             case "car":
                 linkInjuryRisk =
-                        getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.CAR_ONEWAY, time) +
-                                getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.CAR_TWOWAY, time);
                 break;
             case "bike":
                 linkInjuryRisk =
-                        getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.BIKE_MAJOR, time) +
-                                getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.BIKE_MINOR, time);
                 break;
             case "walk":
                 linkInjuryRisk =
-                        getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.PED, time);
                 break;
             default:
@@ -1589,21 +1582,21 @@ public class HealthExposureModelMCR extends AbstractModel implements ModelUpdate
             case autoDriver:
             case autoPassenger:
                 linkInjuryRisk =
-                        getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.CAR_ONEWAY, time) +
-                                getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.CAR_TWOWAY, time);
                 break;
             case bicycle:
                 linkInjuryRisk =
-                        getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.BIKE_MAJOR, time) +
-                                getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.BIKE_MINOR, time);
                 break;
             case walk:
                 linkInjuryRisk =
-                        getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.PED, time);
                 break;
             default:
@@ -1638,7 +1631,7 @@ public class HealthExposureModelMCR extends AbstractModel implements ModelUpdate
 
         double severeInjuryRisk;
         double fatalityRisk;
-        Map<AccidentType, OpenIntFloatHashMap> exposure = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime();
+        Map<AccidentType, OpenIntFloatHashMap> exposure = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime();
 
         switch (mode){
             case autoPassenger:

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentModelMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentModelMEL.java
@@ -3,23 +3,17 @@ package de.tum.bgu.msm.health;
 import cern.colt.map.tfloat.OpenIntFloatHashMap;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.Day;
-import de.tum.bgu.msm.health.airPollutant.emission.MCRHbefaRoadTypeMapping;
-import de.tum.bgu.msm.health.data.DataContainerHealth;
 import de.tum.bgu.msm.health.data.LinkInfo;
-import de.tum.bgu.msm.health.injury.AccidentRateModel;
 import de.tum.bgu.msm.health.injury.AccidentType;
 import de.tum.bgu.msm.models.AbstractModel;
 import de.tum.bgu.msm.models.ModelUpdateListener;
 import de.tum.bgu.msm.properties.Properties;
-import de.tum.bgu.msm.resources.Resources;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
 
@@ -103,7 +97,7 @@ public class AccidentModelMEL extends AbstractModel implements ModelUpdateListen
             model.runCasualtyRateMEL();
 
             for (Id<Link> linkId : model.getAccidentsContext().getLinkId2info().keySet()) {
-                ((HealthDataContainerImpl) dataContainer).getLinkInfoByDay(day).get(linkId).setSevereFatalCasualityExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualityExposureByAccidentTypeByTime());
+                ((HealthDataContainerImpl) dataContainer).getLinkInfoByDay(day).get(linkId).setSevereFatalCasualtyExposureByAccidentTypeByTime(model.getAccidentsContext().getLinkId2info().get(linkId).getSevereFatalCasualtyExposureByAccidentTypeByTime());
             }
 
             logger.info("====================");
@@ -135,7 +129,7 @@ public class AccidentModelMEL extends AbstractModel implements ModelUpdateListen
                     for (int hour = 0; hour < 24; hour++) {
                         // Retrieve the hourly risk map for the accidentType, defaulting to an empty OpenIntFloatHashMap
                         OpenIntFloatHashMap hourlyRiskMap = linkInfo
-                                .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                                .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                                 .getOrDefault(accidentType, new OpenIntFloatHashMap());
 
                         // Add the risk for the current hour, defaulting to 0.0 if not present

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentRateCalculationMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentRateCalculationMEL.java
@@ -52,10 +52,10 @@ public class AccidentRateCalculationMEL {
 
         switch (accidentSeverity){
             case LIGHT:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
                 break;
             case SEVEREFATAL:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, crashRateByTimeOfDay);
                 break;
             default:
                 throw new RuntimeException("Undefined accident severity " + accidentSeverity);

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentRateModelMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentRateModelMEL.java
@@ -930,7 +930,7 @@ public class AccidentRateModelMEL {
     }
 
     private double calculateRiskForMode(AccidentLinkInfo linkInfo, String mode, int hour) {
-        Map<AccidentType, OpenIntFloatHashMap> exposureByType = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime();
+        Map<AccidentType, OpenIntFloatHashMap> exposureByType = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime();
 
         switch (mode) {
             // todo: here normally if ONEWAY is 0 other is non-null and vice versa, same for BIKE ...
@@ -953,72 +953,6 @@ public class AccidentRateModelMEL {
         return map.get(hour);
     }
 
-    /*
-    private void computeAgentCrashRiskMEL(AccidentAgentInfo personInfo) {
-
-        //double lightInjuryRisk = .0;
-        Double severeInjuryRisk = .0;
-        Map<String, Double> PersonInjuryRiskByMode = new HashMap<>();
-
-        // Initialize modes
-        PersonInjuryRiskByMode.put("car", 0.0);
-        PersonInjuryRiskByMode.put("bike", 0.0);
-        PersonInjuryRiskByMode.put("walk", 0.0);
-
-        for(Id<Link> linkId : personInfo.getLinkId2time2mode().keySet()){
-            AccidentLinkInfo linkInfo = this.accidentsContext.getLinkId2info().get(linkId);
-            if(linkInfo == null){
-                log.warn(linkId + " has no Link Info.");
-                continue;
-            }
-
-            for(int hour : personInfo.getLinkId2time2mode().get(linkId).keySet()){
-                String mode = personInfo.getLinkId2time2mode().get(linkId).get(hour);
-                switch (mode){
-                    case "car":
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.CAR_ONEWAY)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR_ONEWAY).get(hour);
-                        }
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.CAR_TWOWAY)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR_TWOWAY).get(hour);
-                        }
-                        if(severeInjuryRisk != null){
-                            PersonInjuryRiskByMode.put("car", PersonInjuryRiskByMode.get("car") + severeInjuryRisk);
-                        }
-
-                        severeInjuryRisk = .0;
-                        break;
-                    case "bike":
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.BIKE_MAJOR)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKE_MAJOR).get(hour);
-                        }
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.BIKE_MINOR)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKE_MINOR).get(hour);
-                        }
-                        if(severeInjuryRisk != null){
-                            PersonInjuryRiskByMode.put("bike", PersonInjuryRiskByMode.get("bike") + severeInjuryRisk);
-                        }
-                        severeInjuryRisk = .0;
-                        break;
-                    case "walk":
-                        if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().containsKey(AccidentType.PED)){
-                            severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
-                        }
-                        if(severeInjuryRisk != null){
-                            PersonInjuryRiskByMode.put("walk", PersonInjuryRiskByMode.get("walk") + severeInjuryRisk);
-                        }
-                        severeInjuryRisk = .0;
-                        break;
-                    default:
-                        throw new RuntimeException("Undefined mode " + mode);
-                }
-            }
-        }
-        //personInfo.setSevereInjuryRisk(severeInjuryRisk);
-        personInfo.setSevereInjuryRiskByMode(PersonInjuryRiskByMode);
-    }
-     */
-
     private void computeAgentCrashRisk(AccidentAgentInfo personInfo) {
 
         double lightInjuryRisk = .0;
@@ -1033,18 +967,18 @@ public class AccidentRateModelMEL {
                 String mode = personInfo.getLinkId2time2mode().get(linkId).get(hour);
                 switch (mode){
                     case "car":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.CAR).get(hour);
                         break;
                     case "bike":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).get(hour);
                         break;
                     case "walk":
-                        lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
-                        severeInjuryRisk += linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
+                        lightInjuryRisk += linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
+                        severeInjuryRisk += linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(AccidentType.PED).get(hour);
                         break;
                     default:
                         throw new RuntimeException("Undefined mode " + mode);
@@ -1066,12 +1000,12 @@ public class AccidentRateModelMEL {
                 float lightCrash = 0.0f;
                 float severeCrash = 0.0f;
 
-                if(linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(accidentType)!=null){
-                    lightCrash = linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                if(linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(accidentType)!=null){
+                    lightCrash = linkInfo.getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 }
 
-                if(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType)!=null){
-                    severeCrash = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                if(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType)!=null){
+                    severeCrash = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 }
 
                  switch (accidentType){
@@ -1101,8 +1035,8 @@ public class AccidentRateModelMEL {
                 lightCasualtyByTime.put(hour,lightCasualty);
                 severeCasualtyByTime.put(hour,severeCasualty);
             }
-            linkInfo.getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyByTime);
-            linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType,severeCasualtyByTime);
+            linkInfo.getLightCasualtyExposureByAccidentTypeByTime().put(accidentType,lightCasualtyByTime);
+            linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType,severeCasualtyByTime);
         }
     }
 
@@ -1141,19 +1075,14 @@ public class AccidentRateModelMEL {
             for(int hour = 0; hour < 24; hour++) {
                 OpenIntFloatHashMap timeMap = this.accidentsContext.getLinkId2info()
                         .get(link.getId())
-                        .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                        .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                         .get(accidentType);
 
                 float severeCasualty = (timeMap != null) ? timeMap.get(hour) : 0.0f;
 
-                //float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                //float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                //float lightCasualtyExposure =0.f;
-
                 float severeCasualtyExposure = 0.f;
                 if(mode.equals("car")){
                     if(analysisEventHandler.getDemand(link.getId(), mode, hour) != 0){
-                        //lightCasualtyExposure = (float) (lightCasualty/((analysisEventHandler.getDemand(link.getId(),mode,hour))*SCALEFACTOR*1.5));
                         severeCasualtyExposure = (float) (severeCasualty/(analysisEventHandler.getDemand(link.getId(), mode, hour) * SCALEFACTOR)); //* SCALEFACTOR)); // todo: why 1.5 in Munich ?? check if SCALEFACTOR should be applied or not ?
                     }else{
                         //log.warn(link.getId()+mode+hour);
@@ -1173,14 +1102,9 @@ public class AccidentRateModelMEL {
                         }
                     }
                 }
-
-                //lightCasualtyExposureByTime.put(hour,lightCasualtyExposure);
-                // TODO: can be optimized, if 0 do not put
-                //severeCasualtyExposure = severeCasualtyExposure * 2.0f;
                 severeCasualtyExposureByTime.put(hour, severeCasualtyExposure);
             }
-            //this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
-            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, severeCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, severeCasualtyExposureByTime);
         }
     }
 
@@ -1211,8 +1135,8 @@ public class AccidentRateModelMEL {
             OpenIntFloatHashMap lightCasualtyExposureByTime = new OpenIntFloatHashMap();
             OpenIntFloatHashMap severeCasualtyExposureByTime = new OpenIntFloatHashMap();
             for(int hour = 0; hour < 24; hour++) {
-                float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                float lightCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                float severeCasualty = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                 float lightCasualtyExposure =0.f;
                 float severeCasualtyExposure = 0.f;
                 if(mode.equals("car")){
@@ -1235,8 +1159,8 @@ public class AccidentRateModelMEL {
                 lightCasualtyExposureByTime.put(hour,lightCasualtyExposure);
                 severeCasualtyExposureByTime.put(hour,severeCasualtyExposure);
             }
-            this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
-            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType,severeCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().put(accidentType,lightCasualtyExposureByTime);
+            this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType,severeCasualtyExposureByTime);
 
         }
     }
@@ -1285,9 +1209,9 @@ public class AccidentRateModelMEL {
                         continue;
                     }
                     double totalCasualty = 0.;
-                    if(accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType) != null){
+                    if(accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType) != null){
                         for(int hour = 0; hour < 24; hour++) {
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                         risk.append(link.getId());
                         risk.append(',');
@@ -1317,9 +1241,9 @@ public class AccidentRateModelMEL {
                     double totalCasualty = 0.;
                     for(int hour = 0; hour<=24; hour++) {
                         if(accidentSeverity.equals(AccidentSeverity.LIGHT)){
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getLightCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }else{
-                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                            totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                         }
                     }
                     risk.append(link.getId());
@@ -1357,7 +1281,7 @@ public class AccidentRateModelMEL {
                     }
                     double totalCasualty = 0.;
                     for(int hour = 0; hour < 24; hour++) {
-                        totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                        totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
                     }
                     risk.append(link.getId());
                     risk.append(',');

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentRateModelOsmMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/AccidentRateModelOsmMEL.java
@@ -9,11 +9,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.LinkEnterEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.accidents.AccidentsModule;
-import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Injector;
 import org.matsim.core.events.EventsManagerImpl;
@@ -351,7 +349,7 @@ public class AccidentRateModelOsmMEL {
                     severeCasualtyExposureByTime.put(hour, exposure);
                 }
                 accidentsContext.getLinkId2info().get(link.getId())
-                        .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                        .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                         .put(accidentType, severeCasualtyExposureByTime);
             }
         }
@@ -411,7 +409,7 @@ public class AccidentRateModelOsmMEL {
     private float getSevereCasualty(Id<Link> linkId, AccidentType accidentType, int hour) {
         OpenIntFloatHashMap timeMap = accidentsContext.getLinkId2info()
                 .get(linkId)
-                .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                 .get(accidentType);
         return timeMap != null ? timeMap.get(hour) : 0.0f;
     }
@@ -443,10 +441,10 @@ public class AccidentRateModelOsmMEL {
                         if (ACCIDENT_TYPES_EXCLUDED.contains(accidentType)) continue;
                         for (AccidentSeverity accidentSeverity : AccidentSeverity.values()) {
                             if (ACCIDENT_SEVERITIES_EXCLUDED.contains(accidentSeverity)) continue;
-                            if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType) != null) {
+                            if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType) != null) {
                                 for (int hour = 0; hour < 24; hour++) {
                                     double casualty = accidentsContext.getLinkId2info().get(link.getId())
-                                            .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                                            .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                                             .get(accidentType).get(hour);
                                     if (casualty > 0) {
                                         writer.printf("%d,%s,%s,%d,%s\n",
@@ -483,10 +481,10 @@ public class AccidentRateModelOsmMEL {
 
                      */
                         double totalCasualty = 0;
-                        if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType) != null) {
+                        if (accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType) != null) {
 
                             for (int hour = 0; hour < 24; hour++) {
-                                totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
+                                totalCasualty += accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().get(accidentType).get(hour);
 
                             }
 
@@ -511,7 +509,7 @@ public class AccidentRateModelOsmMEL {
     private double calculateTotalCasualty(Id<Link> linkId, AccidentType accidentType) {
         OpenIntFloatHashMap timeMap = accidentsContext.getLinkId2info()
                 .get(linkId)
-                .getSevereFatalCasualityExposureByAccidentTypeByTime()
+                .getSevereFatalCasualtyExposureByAccidentTypeByTime()
                 .get(accidentType);
         if (timeMap == null) return 0.0;
         double total = 0.0;

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationMEL.java
@@ -31,9 +31,6 @@ public class CasualtyRateCalculationMEL {
     private int tot_Casualties;
     private int current_Casualties;
 
-    // todo: testing
-    //private Map<Id<Link>, EnumMap<AccidentType, OpenIntFloatHashMap>> severeFatalCasualityRiskByLinkByAccidentTypeByTime = new HashMap<>();
-
     public CasualtyRateCalculationMEL(double scaleFactor, AccidentsContext accidentsContext, AnalysisEventHandler analzyer, AccidentType accidentType, AccidentSeverity accidentSeverity, String basePath, Scenario scenario, double calibrationFactor) {
         this.SCALEFACTOR = scaleFactor;
         this.accidentsContext = accidentsContext;
@@ -148,7 +145,7 @@ public class CasualtyRateCalculationMEL {
 
         switch (accidentSeverity) {
             case SEVEREFATAL:
-                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
+                this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
                 break;
             default:
                 throw new RuntimeException("Undefined accident severity " + accidentSeverity);
@@ -203,7 +200,7 @@ public class CasualtyRateCalculationMEL {
         int val = 0;
 
         //
-        OpenIntFloatHashMap casualtyRateByTimeOfDay = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().getOrDefault(accidentType, new OpenIntFloatHashMap());
+        OpenIntFloatHashMap casualtyRateByTimeOfDay = this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().getOrDefault(accidentType, new OpenIntFloatHashMap());
 
         for (int hour = 0; hour < 24; hour++) {
             if(analzyer.getDemand(link.getId(), getMode(accidentType), hour) > 0 && casualtyRateByTimeOfDay.get(hour) == 0) {
@@ -223,7 +220,7 @@ public class CasualtyRateCalculationMEL {
         }
 
         // update map
-        this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
+        this.accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, casualtyRateByTimeOfDay);
     }
 
     private void printLinkInfo(Link link) {

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationOsmMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/CasualtyRateCalculationOsmMEL.java
@@ -21,13 +21,6 @@ public class CasualtyRateCalculationOsmMEL {
     private Map<Integer, Double> timeOfDayCoef;
     private AccidentType accidentType;
     private AccidentSeverity accidentSeverity;
-    //private Scenario scenario;
-    //private double calibrationFactor;
-    //private int tot_Casualties;
-    //private int current_Casualties;
-
-    // todo: testing
-    //private Map<Id<Link>, EnumMap<AccidentType, OpenIntFloatHashMap>> severeFatalCasualityRiskByLinkByAccidentTypeByTime = new HashMap<>();
 
     public CasualtyRateCalculationOsmMEL(AccidentsContext accidentsContext, AccidentType accidentType, AccidentSeverity accidentSeverity, String basePath) {
         //this.SCALEFACTOR = scaleFactor;
@@ -86,37 +79,8 @@ public class CasualtyRateCalculationOsmMEL {
                 linkCasualtyRateByTime.put(hour, linkCasualtyRate);
             }
             AccidentLinkInfo linkInfo = accidentsContext.getLinkId2info().computeIfAbsent(link.getId(), id -> new AccidentLinkInfo(id));
-            linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime().put(accidentType, linkCasualtyRateByTime);
+            linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime().put(accidentType, linkCasualtyRateByTime);
         }
-
-
-        // testing
-        /*
-        if(osmLink.osmId== 1111480){
-            System.out.println("OSM ID " + osmLink.osmId);
-            System.out.println("===============================================================");
-            printOsmLinkDetails(osmLink);
-            System.out.println("===============================================================");
-            printBinaryLogitCoefficients();
-            System.out.println("===============================================================");
-            for(int hour = 0; hour < 24; hour++) {
-                System.out.println("Hour " + hour + ": " + casualtyRateByTimeOfDay.get(hour));
-            }
-            System.out.println("===============================================================");
-
-            // links
-            for(Link link : osmLink.getNetworkLinks()) {
-                System.out.println("Link ID " + link.getId().toString());
-                System.out.println("===============================================================");
-                for(int hour = 0; hour < 24; hour++) {
-                    float val = accidentsContext.getLinkId2info().get(link.getId()).getSevereFatalCasualityExposureByAccidentTypeByTime().get(accidentType).get(hour);
-                    System.out.println("Hour " + hour + ": " + val);
-                }
-                System.out.println("===============================================================");
-            }
-        }
-
-         */
     }
 
     public void printBinaryLogitCoefficients() {

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/HealthExposureModelMEL.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/HealthExposureModelMEL.java
@@ -2,13 +2,11 @@ package de.tum.bgu.msm.health;
 
 import cern.colt.map.tfloat.OpenIntFloatHashMap;
 import com.google.common.collect.Iterables;
-import com.google.common.math.LongMath;
 import de.tum.bgu.msm.container.DataContainer;
 import de.tum.bgu.msm.data.*;
 import de.tum.bgu.msm.data.job.JobMEL;
 import de.tum.bgu.msm.data.person.Gender;
 import de.tum.bgu.msm.data.person.Person;
-import de.tum.bgu.msm.data.travelTimes.SkimTravelTimes;
 import de.tum.bgu.msm.health.data.*;
 import de.tum.bgu.msm.health.diseaseModelOffline.HealthExposuresReader;
 import de.tum.bgu.msm.health.injury.AccidentType;
@@ -23,16 +21,12 @@ import de.tum.bgu.msm.properties.Properties;
 import de.tum.bgu.msm.util.concurrent.ConcurrentExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.locationtech.jts.geom.Coordinate;
-import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.PopulationFactory;
-import org.matsim.contrib.analysis.vsp.traveltimedistance.TripsExtractor;
 import org.matsim.contrib.dvrp.trafficmonitoring.TravelTimeUtils;
 import org.matsim.contrib.emissions.Pollutant;
 import org.matsim.core.config.Config;
@@ -54,12 +48,9 @@ import routing.BicycleConfigGroup;
 import routing.TransportModeNetworkFilter;
 import routing.WalkConfigGroup;
 import routing.components.Gradient;
-import routing.components.JctStress;
 import routing.components.LinkAmbience;
 import routing.components.LinkStress;
 import routing.travelDisutility.ActiveDisutilityPrecalc;
-import routing.travelTime.BicycleLinkSpeedCalculatorImpl;
-import routing.travelTime.BicycleTravelTime;
 import routing.travelTime.WalkLinkSpeedCalculatorImpl;
 import routing.travelTime.WalkTravelTime;
 
@@ -1533,21 +1524,21 @@ public class HealthExposureModelMEL extends AbstractModel implements ModelUpdate
         switch (mode) {
             case "car":
                 linkInjuryRisk =
-                        getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.CAR_ONEWAY, time) +
-                                getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.CAR_TWOWAY, time);
                 break;
             case "bike":
                 linkInjuryRisk =
-                        getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.BIKE_MAJOR, time) +
-                                getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.BIKE_MINOR, time);
                 break;
             case "walk":
                 linkInjuryRisk =
-                        getRiskValue2(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue2(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.PED, time);
                 break;
             default:
@@ -1562,21 +1553,21 @@ public class HealthExposureModelMEL extends AbstractModel implements ModelUpdate
             case autoDriver:
             case autoPassenger:
                 linkInjuryRisk =
-                        getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.CAR_ONEWAY, time) +
-                                getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.CAR_TWOWAY, time);
                 break;
             case bicycle:
                 linkInjuryRisk =
-                        getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.BIKE_MAJOR, time) +
-                                getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                                getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                         AccidentType.BIKE_MINOR, time);
                 break;
             case walk:
                 linkInjuryRisk =
-                        getRiskValue(linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime(),
+                        getRiskValue(linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime(),
                                 AccidentType.PED, time);
                 break;
             default:
@@ -1611,7 +1602,7 @@ public class HealthExposureModelMEL extends AbstractModel implements ModelUpdate
 
         double severeInjuryRisk;
         double fatalityRisk;
-        Map<AccidentType, OpenIntFloatHashMap> exposure = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime();
+        Map<AccidentType, OpenIntFloatHashMap> exposure = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime();
 
         switch (mode){
             case autoPassenger:

--- a/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/MatsimTransportModelMELHealth.java
+++ b/useCases/melbourne/src/main/java/de/tum/bgu/msm/health/MatsimTransportModelMELHealth.java
@@ -401,6 +401,10 @@ public final class MatsimTransportModelMELHealth implements TransportModel {
         bikePedConfig.routing().removeModeRoutingParams("walk");
         bikePedConfig.routing().removeModeRoutingParams("pt");
 
+        if (properties.transportModel.includeAccessEgress) {
+            bikePedConfig.routing().setAccessEgressType(RoutingConfigGroup.AccessEgressType.accessEgressModeToLink);
+        }
+
 
         // BIKE ATTRIBUTES
         List<ToDoubleFunction<Link>> bikeAttributes = new ArrayList<>();

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/HealthModelMuc.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/healthMuc/HealthModelMuc.java
@@ -397,7 +397,7 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
     private double[] getLinkSevereFatalInjuryRisk(Mode mode, int hour, LinkInfo linkInfo) {
         double severeInjuryRisk;
         double fatalityRisk;
-        Map<AccidentType, OpenIntFloatHashMap> exposure = linkInfo.getSevereFatalCasualityExposureByAccidentTypeByTime();
+        Map<AccidentType, OpenIntFloatHashMap> exposure = linkInfo.getSevereFatalCasualtyExposureByAccidentTypeByTime();
         switch (mode){
             case autoDriver:
             case autoPassenger:
@@ -421,29 +421,6 @@ public class HealthModelMuc extends AbstractModel implements ModelUpdateListener
 
         return new double[]{severeInjuryRisk,fatalityRisk};
     }
-
-    /*private double getLinkLightInjuryRisk(Mode mode, int hour, LinkInfo linkInfo) {
-        double lightInjuryRisk = 0.;
-        switch (mode){
-            case autoDriver:
-            case autoPassenger:
-                lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.CAR).getOrDefault(hour,0.);
-                break;
-            case bicycle:
-                lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKECAR).getOrDefault(hour,0.);
-                lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.BIKEBIKE).getOrDefault(hour,0.);
-                break;
-            case walk:
-                lightInjuryRisk += linkInfo.getLightCasualityExposureByAccidentTypeByTime().get(AccidentType.PED).getOrDefault(hour,0.);
-                break;
-            default:
-                throw new RuntimeException("Undefined mode " + mode);
-        }
-
-
-        return lightInjuryRisk;
-    }
-*/
 
     //TODO: concurrent
     private void calculatePersonHealthExposures() {


### PR DESCRIPTION
The accident model introduced variables with a typo in a number of classes ("Casuality" instead of "Casualty").

Related code in comments has also been removed.

This isn't a problem, but just low hanging fruit to tidy this up and close the issue.